### PR TITLE
firefox_gnome_theme.py: Add support for Firefox Snap

### DIFF
--- a/firefox_gnome_theme.py
+++ b/firefox_gnome_theme.py
@@ -120,6 +120,7 @@ class FirefoxGnomeTheme2Plugin(IPlugin):
             "~/.librewolf",
             "~/.var/app/org.mozilla.firefox/.mozilla/firefox",
             "~/.var/app/io.gitlab.librewolf-community/.librewolf",
+            "~/snap/firefox/common/.mozilla/firefox",
         ]:
             try:
                 directory = Path(path).expanduser()


### PR DESCRIPTION
Will also require adding the path to Flatpak permissions in the main Gradience repo.

Closes GradienceTeam/Gradience#686 (assuming aforementioned addition).